### PR TITLE
explicit split('\n') for cross-platform

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ def main():
         requirements_file = 'base.txt'
     requirements_file = os.path.join('requirements', requirements_file)
     with open(requirements_file) as requirements_reader:
-        requires = requirements_reader.read().splitlines()
+        requires = requirements_reader.read().split('\n')
     # Get package description
     with open('README.rst') as readme_reader:
         long_description = readme_reader.read()


### PR DESCRIPTION
splitlines() looks for the running platform's linefeed (\n) character, and so doesn't split LF on Windows which uses CRLF.
Explicitly looking for any linefeed this way does, even without changing windows.txt LF to CRLF (which was also working).